### PR TITLE
Center teleprompter text and add pre-speech instructions

### DIFF
--- a/pages/speech.js
+++ b/pages/speech.js
@@ -179,14 +179,7 @@ useEffect(() => {
   return () => clearTimeout(timerRef.current);
 }, [started, paused, revealed, turnIndex, turnPoints, totalWords, wpm, finished]);
 
-// Auto-scroll the teleprompter pane as words reveal
-useEffect(() => {
-  if (!started || !teleRef.current) return;
-  teleRef.current.scrollTo({
-    top: teleRef.current.scrollHeight,
-    behavior: "smooth",
-  });
-}, [revealed, paragraphs, started]);
+// Teleprompter text is centered via CSS; no scroll handling needed
 
 // Optional: lock page scroll while overlays are visible
 useEffect(() => {
@@ -311,7 +304,8 @@ useEffect(() => {
 
         {!started ? (
           <div className="center">
-            <button className="btn primary" onClick={onStart}>▶ Start Speech</button>
+            <p className="speechNote">Hold your phone horizontally and 6 inches in front of your face, then hit begin speech.</p>
+            <button className="btn primary" onClick={onStart}>▶ Begin Speech</button>
           </div>
         ) : (
           <div className="teleWrap">
@@ -335,13 +329,15 @@ useEffect(() => {
               </div>
             ) : null}
 
-<div className="teleprompter" ref={teleRef}>
-  {paragraphs.length > 0 ? (
-    paragraphs.map((p, i) => <p key={i} className="speech">{p}</p>)
-  ) : (
-    <p className="speech">{pre.words.slice(0, revealed).join(" ")}</p>
-  )}
-</div>
+            <div className="teleprompter" ref={teleRef}>
+              <div className="teleText">
+                {paragraphs.length > 0 ? (
+                  paragraphs.map((p, i) => <p key={i} className="speech">{p}</p>)
+                ) : (
+                  <p className="speech">{pre.words.slice(0, revealed).join(" ")}</p>
+                )}
+              </div>
+            </div>
 
           </div>
         )}

--- a/styles/app.css
+++ b/styles/app.css
@@ -204,7 +204,7 @@ button:active{ transform: translateY(1px); box-shadow: 0 1px 0 var(--gold-dark);
 /* Readability */
 .speech{
   margin: 0 0 1.1rem 0;
-  text-align: left;
+  text-align: center;
   line-height: 1.75;
   font-size: 1.8rem;                /* bigger by default */
   max-width: 68ch;                  /* sensible line length */
@@ -485,7 +485,7 @@ button:active{ transform: translateY(1px); box-shadow: 0 1px 0 var(--gold-dark);
 /* Readability */
 .speech{
   margin: 0 0 1.1rem 0;
-  text-align: left;
+  text-align: center;
   line-height: 1.75;
   font-size: 1.8rem;                /* bigger by default */
   max-width: 68ch;                  /* sensible line length */
@@ -552,11 +552,27 @@ button:active{ transform: translateY(1px); box-shadow: 0 1px 0 var(--gold-dark);
   z-index: 20;
 }
 
-/* Teleprompter scroll area: limited height + smooth scroll */
+/* Teleprompter area: keep text centered */
 .teleprompter{
+  position: relative;
   max-height: 60vh;   /* keep it within the viewport */
-  overflow-y: auto;
-  scroll-behavior: smooth;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.teleText{
+  position: absolute;
+  bottom: 50%;
+  transform: translateY(50%);
+  width: 100%;
+  text-align: center;
+}
+
+.speechNote{
+  text-align: center;
+  margin-bottom: 12px;
 }
 
 /* Center overlays on the screen (not inside the text box) */
@@ -583,9 +599,20 @@ body.modal-open {
 
 /* Teleprompter scroll area: fixed height and smooth scroll */
 .teleprompter{
+  position: relative;
   max-height: 60vh;   /* keeps content within the viewport */
-  overflow-y: auto;
-  scroll-behavior: smooth;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.teleText{
+  position: absolute;
+  bottom: 50%;
+  transform: translateY(50%);
+  width: 100%;
+  text-align: center;
 }
 
 /* Center overlays on the screen (TURN/Finish) */


### PR DESCRIPTION
## Summary
- Center teleprompter text and keep it fixed on screen
- Add pre-speech guidance for phone positioning
- Style note and teleprompter elements for centered presentation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b67a52b6988333b804aed80e097707