### PR TITLE
Improve teleprompter word reveal and centering

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -606,18 +606,26 @@ body.modal-open {
 .teleprompter{
   position: relative;
   max-height: 60vh;   /* keeps content within the viewport */
-  overflow: hidden;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  overflow-y: auto;
+  scroll-behavior: smooth;
 }
 
 .teleText{
-  position: absolute;
-  bottom: 50%;
-  transform: translateY(50%);
   width: 100%;
   text-align: center;
+}
+
+.word{
+  visibility: hidden;
+  display: inline-block;
+}
+
+.word.shown{
+  visibility: visible;
+}
+
+.word.highlight{
+  background: #fff3a5;
 }
 
 /* Center overlays on the screen (TURN/Finish) */


### PR DESCRIPTION
## Summary
- Keep teleprompter scroll centered on the latest word
- Reveal speech text one word at a time with highlight on recent words
- Add styles for word highlighting and smoother scrolling

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b681b9aae08333917eb20701020571