### PR TITLE
Limit mobile topic box height and rename picker

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -100,7 +100,7 @@ export default function Setup() {
               setTopic(DEFAULT_TOPICS[Math.floor(Math.random() * DEFAULT_TOPICS.length)])
             }
           >
-            Pick one
+            choose for me
           </button>
         </div>
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -635,3 +635,10 @@ body.modal-open {
 body.modal-open{
   overflow: hidden;
 }
+
+@media (max-width: 480px) and (orientation: portrait){
+  textarea{
+    max-height: 8rem;
+    overflow: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- cap topic textarea height on mobile portrait screens to avoid an overly tall box
- rename random topic button to "choose for me"

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b682962b108333b03d9c8b05dafac2