### PR TITLE
Fix teleprompter not displaying speech

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -67,10 +67,10 @@ export default function Setup() {
       router.push({
         pathname: "/speech",
         query: {
-          speech: encodeURIComponent(s),
+          speech: s,
           confidence,
           senators: String(senators),
-          topic: encodeURIComponent(topic || "Address to the Roman People")
+          topic: topic || "Address to the Roman People"
         }
       });
     } catch (e) {

--- a/pages/speech.js
+++ b/pages/speech.js
@@ -13,8 +13,17 @@ export default function Speech() {
     topic: encodedTopic,
   } = router.query;
 
-  const title = decodeURIComponent(encodedTopic || "Address to the Roman People");
-  const rawSpeech = decodeURIComponent(encoded || "");
+  function safeDecode(str, fallback = "") {
+    if (typeof str !== "string") return fallback;
+    try {
+      return decodeURIComponent(str);
+    } catch {
+      return str;
+    }
+  }
+
+  const title = safeDecode(encodedTopic, "Address to the Roman People");
+  const rawSpeech = safeDecode(encoded);
   const teleRef = useRef(null);
   const wordRefs = useRef([]);
 


### PR DESCRIPTION
## Summary
- Remove manual URL encoding when navigating to the teleprompter so full speech text reaches the page
- Decode query parameters safely on the teleprompter page to handle both encoded and raw inputs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6853732848333be7dc78b1176f261