### PR TITLE
Adjust speech length based on player count

### DIFF
--- a/pages/api/generate.js
+++ b/pages/api/generate.js
@@ -19,6 +19,11 @@ export default async function handler(req, res) {
 
   let { topic, senators, confidence } = req.body || {};
   topic = (topic || "").trim();
+  const numPlayers = Math.max(1, parseInt(senators, 10) || 1);
+
+  // Determine target speech length based on number of players
+  const speechSeconds = 24 + numPlayers * 8;
+  const approxWords = Math.round((speechSeconds / 60) * 180); // 180 wpm baseline
 
   // If no topic, pick from our funny defaults—and also check cache first
   if (!topic) {
@@ -44,7 +49,7 @@ export default async function handler(req, res) {
       `Voice: confident, theatrical, self‑aggrandizing, with occasional jabs at senators and rival generals.`,
       `Pacing: short to medium sentences; vivid imagery; Roman references (aqueducts, legions, augurs, SPQR, laurel wreaths).`,
       `Close with a paragraph that begins with "In conclusion," (exact phrase) and then 2–4 more sentences. Do NOT end immediately after "In conclusion,"`,
-      `Length: about 60–120 seconds spoken (roughly 130–250 words).`,
+      `Length: about ${speechSeconds} seconds spoken (roughly ${approxWords} words).`,
       `End with [FINISH].`
     ].join('\n');
 


### PR DESCRIPTION
## Summary
- Tailor generated speech duration to player count using `(24 + players * 8)` seconds
- Reflect calculated timing and word count in OpenAI prompt for more precise output

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b69247cfe0833388ff9898ddad68c0